### PR TITLE
Feat: mongodb연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ cmake-build-*/
 # IntelliJ
 out/
 
+#yml파일
+application-local.yml
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,8 +19,8 @@ spring:
 
   data:
     mongodb:
-      host: 43.203.235.252
+      host: localhost
       port: 27017
-      database: algoy_ai
-      username: algoy_admin
-      password: 0000
+      database: mydatabase
+      username: myuser
+      password: mypassword


### PR DESCRIPTION
## 요약
- local과 mongoDB 서버 yml 파일 분리 및 mongoDB 연결

## 관련 이슈
- related to #9 

## 변경 사항
- yml 파일 분리, local은 ignore에 추가

## 기타
- EC2에 도커에서 MongoDB 설치 및 연동
