### PR TITLE
Chore: build.gradle에 websocket과 redis 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
## 요약
- build.gradle에 websocket과 redis 종속성 추가

## 관련 이슈
- Closed #13 

## 변경 사항
- NoSQL - Spring Data Redis (Access + Driver), Messaging - WebSocket 종속성 추가
