### PR TITLE
Chore: Redis 관련 종속성 및 설정 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,11 +19,4 @@ spring:
 
   data:
     mongodb:
-      host: 43.203.235.252
-      port: 27017
-      database: algoy_ai
-      username: algoy_admin
-      password: 0000
-    redis:
-      host: localhost
-      port: 6379
+      uri: mongodb://algoy_admin:0000@43.203.235.252:27017/algoy_ai


### PR DESCRIPTION
## 요약
- redis를 사용하지 않기 때문에 관련 설정을 삭제하였습니다.
- 추가적으로 mongoDB는 uri 방식으로 한 줄로 나타내었습니다.

## 관련 이슈
- Closed #38 

## 변경 사항
- build.gradle redis 종속성 삭제
- yml에서 redis 삭제

## 기타
-  yml에서 mongoDB 부분을 uri로 변경
