### PR TITLE
Bug: API 요청/응답을 받지 못하는 부분 수정

### DIFF
--- a/src/main/java/com/example/algoyai/config/WebConfig.java
+++ b/src/main/java/com/example/algoyai/config/WebConfig.java
@@ -1,24 +1,24 @@
-//package com.example.algoyai.config;
-//
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.web.servlet.config.annotation.CorsRegistry;
-//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-//
-//@Configuration
-//public class WebConfig {
-//
-//	@Bean
-//	public WebMvcConfigurer corsConfigurer() {
-//		return new WebMvcConfigurer() {
-//			@Override
-//			public void addCorsMappings(CorsRegistry registry) {
-//				registry.addMapping("/ai/**")
-//					.allowedOriginPatterns("*")  // 모든 도메인 허용
-//					.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-//					.allowedHeaders("*")
-//					.allowCredentials(true);
-//			}
-//		};
-//	}
-//}
+package com.example.algoyai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+	@Bean
+	public WebMvcConfigurer corsConfigurer() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addCorsMappings(CorsRegistry registry) {
+				registry.addMapping("/ai/**")
+					.allowedOriginPatterns("*")  // 모든 도메인 허용
+					.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+					.allowedHeaders("*")
+					.allowCredentials(true);
+			}
+		};
+	}
+}

--- a/src/main/java/com/example/algoyai/util/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/algoyai/util/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-/*package com.example.algoyai.util;
+package com.example.algoyai.util;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,4 +12,4 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<String> handleException(Exception e) {
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal Server Error: " + e.getMessage());
 	}
-}*/
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 
   data:
     mongodb:
-      uri: mongodb://algoy_admin:0000@43.203.235.252:27017/algoy_ai
+      uri: mongodb://algoy_admin:0000@43.203.235.252:27017/algoy_ai?authSource=admin
 
 ai:
   api:


### PR DESCRIPTION
## 요약
- API 요청/응답을 받지 못하는 부분 해결

## 관련 이슈
- Closed #61 

## 변경 사항
- application.yml:
- 주석 처리된 코드 주석 제거 (WebConfig.java, GlobalExceptionHandler.java)

## 기타
- 문제의 원인이 mongoDB의 권한 문제였습니다! 그래서 ec2 서버의 MongoDB에 다음과 같은 설정을 해야할 것 같습니다.
   - mongo shell에 다음과 같이 admin 권한으로 들어가기 -> mongosh 
   - "mongodb://algoy_admin:0000@43.203.235.252:27017/algoy_ai" --authenticationDatabase admin
   - admin 컬렉션 들어가기 -> use admin
   - algoy_user 정보 조회하기 -> db.getUser('algoy_admin')
   - algoy_user에게 권한 부여하기 -> db.grantRolesToUser('algoy_admin', [{role: 'readWrite', db: 'algoy_ai'}])
