### PR TITLE
Chore: application.yml에 Web 서버 url 환경 변수 추가

### DIFF
--- a/src/main/java/com/example/algoyai/config/WebConfig.java
+++ b/src/main/java/com/example/algoyai/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.example.algoyai.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,13 +9,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig {
 
+	@Value("${ai-frontend.url}")
+	private String frontendUrl;
+
 	@Bean
 	public WebMvcConfigurer corsConfigurer() {
 		return new WebMvcConfigurer() {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/ai/**")
-					.allowedOrigins("http://localhost:8081")  // 프론트엔드 서버 주소
+					.allowedOrigins(frontendUrl)  // 프론트엔드 서버 주소
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 					.allowedHeaders("*")
 					.allowCredentials(true);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 server:
   port: 8082
 
+ai-frontend:
+  url: ${WEB_IP}
+
 spring:
   profiles:
     active: default
@@ -26,7 +29,7 @@ spring:
 ai:
   api:
     url: https://kdt-api-function.azurewebsites.net/api/v1/question/sse-streaming
-    key: d4cd1faf-9253-4ef1-ad2d-548cbed5c381
+    key: 9158381d-b009-4891-8982-51a6a8dac707
 
 allenApi:
   url: https://kdt-api-function.azurewebsites.net/api/v1/question?content=


### PR DESCRIPTION
## 요약
- application.yml에 Web 서버의 ip와 포트 url을 환경 변수로 추가

## 관련 이슈
- Closed #84 

## 변경 사항
- application.yml에 Web 서버의 ip와 포트 url을 환경 변수로 추가
- WebConfig에 @Value를 이용해서 url로 입력 받도록 추가