### PR TITLE
Test: 챗봇 테스트 코드 작성하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'org.apache.commons:commons-text:1.9'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation "org.testcontainers:junit-jupiter:1.17.3"
+    testImplementation "org.testcontainers:mongodb:1.17.3"
+    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.6.1'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/test/java/com/example/algoyai/controller/chatbot/ChatControllerTest.java
+++ b/src/test/java/com/example/algoyai/controller/chatbot/ChatControllerTest.java
@@ -17,126 +17,162 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+/**
+ * @author JSW
+ * ChatController의 동작을 검증하는 테스트 클래스입니다.
+ */
 @ExtendWith(MockitoExtension.class)
 class ChatControllerTest {
 
-	@Mock
-	private ChatService chatService;
+  @Mock private ChatService chatService;
 
-	@InjectMocks
-	private ChatController chatController;
+  @InjectMocks private ChatController chatController;
+  private WebTestClient webTestClient;
 
-	private WebTestClient webTestClient;
+  /** 테스트 전에 WebTestClient를 ChatController에 바인딩하여 초기 설정을 수행합니다. */
+  @BeforeEach
+  void setUp() {
+    webTestClient = WebTestClient.bindToController(chatController).build();
+  }
 
-	@BeforeEach
-	void setUp() {
-		webTestClient = WebTestClient.bindToController(chatController).build();
-	}
+  /**
+   * 채팅 메시지를 정상적으로 처리하고 단일 응답을 반환하는 경우의 테스트입니다. "Hello, AI!" 메시지를 보내면, AI가 "Hello, Human!"으로 응답하는 것을
+   * 검증합니다.
+   */
+  @Test
+  void testStreamChatResponse_Success() {
+    // Given: 입력 메시지와 기대하는 응답 설정
+    String content = "Hello, AI!";
+    ChatMessageDto responseDto =
+        new ChatMessageDto("complete", new ChatMessageDto.ChatResponseData("Hello, Human!", "AI"));
 
-	@Test
-	void testStreamChatResponse_Success() {
-		String content = "Hello, AI!";
-		ChatMessageDto responseDto = new ChatMessageDto("complete",
-			new ChatMessageDto.ChatResponseData("Hello, Human!", "AI"));
+    // When: ChatService의 getChatResponse가 특정 값을 반환하도록 모킹
+    when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(responseDto));
 
-		when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(responseDto));
+    // Then: API 호출 결과가 예상과 일치하는지 검증
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder.path("/ai/api/chat/stream").queryParam("content", content).build())
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBodyList(ChatMessageDto.class)
+        .hasSize(1)
+        .contains(responseDto);
+  }
 
-		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder
-				.path("/ai/api/chat/stream")
-				.queryParam("content", content)
-				.build())
-			.accept(MediaType.TEXT_EVENT_STREAM)
-			.exchange()
-			.expectStatus().isOk()
-			.expectBodyList(ChatMessageDto.class)
-			.hasSize(1)
-			.contains(responseDto);
-	}
+  /** 빈 문자열을 콘텐츠로 보냈을 때 응답이 없는지 확인하는 테스트입니다. */
+  @Test
+  void testStreamChatResponse_EmptyContent() {
+    // Given: 빈 문자열 콘텐츠
+    String content = "";
 
-	@Test
-	void testStreamChatResponse_EmptyContent() {
-		String content = "";
+    // When: 빈 콘텐츠로 API 호출
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder.path("/ai/api/chat/stream").queryParam("content", content).build())
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .exchange()
 
-		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder
-				.path("/ai/api/chat/stream")
-				.queryParam("content", content)
-				.build())
-			.accept(MediaType.TEXT_EVENT_STREAM)
-			.exchange()
-			.expectStatus().isOk()
-			.expectBodyList(ChatMessageDto.class)
-			.hasSize(0);
-	}
+        // Then: 응답 메시지가 없음을 확인
+        .expectStatus()
+        .isOk()
+        .expectBodyList(ChatMessageDto.class)
+        .hasSize(0);
+  }
 
-	@Test
-	void testStreamChatResponse_LongContent() {
-		String content = "This is a very long message. ".repeat(100);
-		ChatMessageDto responseDto = new ChatMessageDto("complete",
-			new ChatMessageDto.ChatResponseData("Response to long message", "AI"));
+  /** 매우 긴 콘텐츠를 보냈을 때 응답을 정상적으로 처리하는지 확인하는 테스트입니다. */
+  @Test
+  void testStreamChatResponse_LongContent() {
+    // Given: 매우 긴 문자열 콘텐츠와 기대되는 응답 설정
+    String content = "This is a very long message. ".repeat(100);
+    ChatMessageDto responseDto =
+        new ChatMessageDto(
+            "complete", new ChatMessageDto.ChatResponseData("Response to long message", "AI"));
 
-		when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(responseDto));
+    // When: ChatService가 긴 메시지에 대한 응답을 반환하도록 모킹
+    when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(responseDto));
 
-		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder
-				.path("/ai/api/chat/stream")
-				.queryParam("content", content)
-				.build())
-			.accept(MediaType.TEXT_EVENT_STREAM)
-			.exchange()
-			.expectStatus().isOk()
-			.expectBodyList(ChatMessageDto.class)
-			.hasSize(1)
-			.contains(responseDto);
-	}
+    // Then: API 호출 결과가 예상과 일치하는지 검증
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder.path("/ai/api/chat/stream").queryParam("content", content).build())
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBodyList(ChatMessageDto.class)
+        .hasSize(1)
+        .contains(responseDto);
+  }
 
-	@Test
-	void testStreamChatResponse_MultipleMessages() {
-		String content = "Tell me a story";
-		ChatMessageDto response1 = new ChatMessageDto("partial",
-			new ChatMessageDto.ChatResponseData("Once upon a time", "AI"));
-		ChatMessageDto response2 = new ChatMessageDto("complete",
-			new ChatMessageDto.ChatResponseData("there was a brave programmer.", "AI"));
+  /**
+   * 여러 개의 메시지를 순차적으로 응답받는 경우를 테스트합니다. 첫 번째 응답은 "Once upon a time", 두 번째 응답은 "there was a brave
+   * programmer."입니다.
+   */
+  @Test
+  void testStreamChatResponse_MultipleMessages() {
+    // Given: 입력 메시지와 두 개의 예상 응답 설정
+    String content = "Tell me a story";
+    ChatMessageDto response1 =
+        new ChatMessageDto(
+            "partial", new ChatMessageDto.ChatResponseData("Once upon a time", "AI"));
+    ChatMessageDto response2 =
+        new ChatMessageDto(
+            "complete", new ChatMessageDto.ChatResponseData("there was a brave programmer.", "AI"));
 
-		when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(response1, response2));
+    // When: ChatService가 순차적으로 응답을 반환하도록 모킹
+    when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(response1, response2));
 
-		Flux<ChatMessageDto> result = webTestClient.get()
-			.uri(uriBuilder -> uriBuilder
-				.path("/ai/api/chat/stream")
-				.queryParam("content", content)
-				.build())
-			.accept(MediaType.TEXT_EVENT_STREAM)
-			.exchange()
-			.expectStatus().isOk()
-			.returnResult(ChatMessageDto.class)
-			.getResponseBody();
+    // Then: API 호출 결과가 두 개의 응답을 순차적으로 받는지 검증
+    Flux<ChatMessageDto> result =
+        webTestClient
+            .get()
+            .uri(
+                uriBuilder ->
+                    uriBuilder.path("/ai/api/chat/stream").queryParam("content", content).build())
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .returnResult(ChatMessageDto.class)
+            .getResponseBody();
 
-		StepVerifier.create(result)
-			.expectNext(response1)
-			.expectNext(response2)
-			.verifyComplete();
-	}
+    StepVerifier.create(result).expectNext(response1).expectNext(response2).verifyComplete();
+  }
 
-	@Test
-	void testStreamChatResponse_InputSanitization() {
-		String content = "<script>alert('XSS');</script>";
-		String sanitizedContent = InputSanitizer.sanitize(content);
-		ChatMessageDto responseDto = new ChatMessageDto("complete",
-			new ChatMessageDto.ChatResponseData("Sanitized response", "AI"));
+  /** 입력 내용에 대해 XSS 등의 악의적인 스크립트가 포함된 경우, 이를 정상적으로 필터링(입력 정화)하여 응답하는지 테스트합니다. */
+  @Test
+  void testStreamChatResponse_InputSanitization() {
+    // Given: 악성 스크립트가 포함된 입력 메시지와 정화된 콘텐츠 및 예상 응답 설정
+    String content = "<script>alert('XSS');</script>";
+    String sanitizedContent = InputSanitizer.sanitize(content);
+    ChatMessageDto responseDto =
+        new ChatMessageDto(
+            "complete", new ChatMessageDto.ChatResponseData("Sanitized response", "AI"));
 
-		when(chatService.getChatResponse(sanitizedContent)).thenReturn(Flux.just(responseDto));
+    // When: 정화된 콘텐츠에 대해 ChatService가 응답을 반환하도록 모킹
+    when(chatService.getChatResponse(sanitizedContent)).thenReturn(Flux.just(responseDto));
 
-		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder
-				.path("/ai/api/chat/stream")
-				.queryParam("content", content)
-				.build())
-			.accept(MediaType.TEXT_EVENT_STREAM)
-			.exchange()
-			.expectStatus().isOk()
-			.expectBodyList(ChatMessageDto.class)
-			.hasSize(1)
-			.contains(responseDto);
-	}
+    // Then: API 호출 결과가 예상대로 정화된 응답을 반환하는지 검증
+    webTestClient
+        .get()
+        .uri(
+            uriBuilder ->
+                uriBuilder.path("/ai/api/chat/stream").queryParam("content", content).build())
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBodyList(ChatMessageDto.class)
+        .hasSize(1)
+        .contains(responseDto);
+  }
 }

--- a/src/test/java/com/example/algoyai/controller/chatbot/ChatControllerTest.java
+++ b/src/test/java/com/example/algoyai/controller/chatbot/ChatControllerTest.java
@@ -1,0 +1,142 @@
+package com.example.algoyai.controller.chatbot;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.example.algoyai.model.dto.chatbot.ChatMessageDto;
+import com.example.algoyai.service.chatbot.ChatService;
+import com.example.algoyai.util.InputSanitizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class ChatControllerTest {
+
+	@Mock
+	private ChatService chatService;
+
+	@InjectMocks
+	private ChatController chatController;
+
+	private WebTestClient webTestClient;
+
+	@BeforeEach
+	void setUp() {
+		webTestClient = WebTestClient.bindToController(chatController).build();
+	}
+
+	@Test
+	void testStreamChatResponse_Success() {
+		String content = "Hello, AI!";
+		ChatMessageDto responseDto = new ChatMessageDto("complete",
+			new ChatMessageDto.ChatResponseData("Hello, Human!", "AI"));
+
+		when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(responseDto));
+
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/ai/api/chat/stream")
+				.queryParam("content", content)
+				.build())
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBodyList(ChatMessageDto.class)
+			.hasSize(1)
+			.contains(responseDto);
+	}
+
+	@Test
+	void testStreamChatResponse_EmptyContent() {
+		String content = "";
+
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/ai/api/chat/stream")
+				.queryParam("content", content)
+				.build())
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBodyList(ChatMessageDto.class)
+			.hasSize(0);
+	}
+
+	@Test
+	void testStreamChatResponse_LongContent() {
+		String content = "This is a very long message. ".repeat(100);
+		ChatMessageDto responseDto = new ChatMessageDto("complete",
+			new ChatMessageDto.ChatResponseData("Response to long message", "AI"));
+
+		when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(responseDto));
+
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/ai/api/chat/stream")
+				.queryParam("content", content)
+				.build())
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBodyList(ChatMessageDto.class)
+			.hasSize(1)
+			.contains(responseDto);
+	}
+
+	@Test
+	void testStreamChatResponse_MultipleMessages() {
+		String content = "Tell me a story";
+		ChatMessageDto response1 = new ChatMessageDto("partial",
+			new ChatMessageDto.ChatResponseData("Once upon a time", "AI"));
+		ChatMessageDto response2 = new ChatMessageDto("complete",
+			new ChatMessageDto.ChatResponseData("there was a brave programmer.", "AI"));
+
+		when(chatService.getChatResponse(anyString())).thenReturn(Flux.just(response1, response2));
+
+		Flux<ChatMessageDto> result = webTestClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/ai/api/chat/stream")
+				.queryParam("content", content)
+				.build())
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.exchange()
+			.expectStatus().isOk()
+			.returnResult(ChatMessageDto.class)
+			.getResponseBody();
+
+		StepVerifier.create(result)
+			.expectNext(response1)
+			.expectNext(response2)
+			.verifyComplete();
+	}
+
+	@Test
+	void testStreamChatResponse_InputSanitization() {
+		String content = "<script>alert('XSS');</script>";
+		String sanitizedContent = InputSanitizer.sanitize(content);
+		ChatMessageDto responseDto = new ChatMessageDto("complete",
+			new ChatMessageDto.ChatResponseData("Sanitized response", "AI"));
+
+		when(chatService.getChatResponse(sanitizedContent)).thenReturn(Flux.just(responseDto));
+
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/ai/api/chat/stream")
+				.queryParam("content", content)
+				.build())
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBodyList(ChatMessageDto.class)
+			.hasSize(1)
+			.contains(responseDto);
+	}
+}

--- a/src/test/java/com/example/algoyai/repository/chatbot/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/example/algoyai/repository/chatbot/ChatMessageRepositoryTest.java
@@ -12,124 +12,153 @@ import reactor.test.StepVerifier;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 
+/**
+ * @author JSW
+ * ChatMessageRepository의 동작을 검증하는 테스트 클래스입니다.
+ */
 @DataMongoTest
 public class ChatMessageRepositoryTest {
 
-	@Autowired
-	private ChatMessageRepository chatMessageRepository;
+  @Autowired private ChatMessageRepository chatMessageRepository;
 
-	@BeforeEach
-	public void setUp() {
-		chatMessageRepository.deleteAll().block();
-	}
+  /** 각 테스트 실행 전에 저장소를 비웁니다. */
+  @BeforeEach
+  public void setUp() {
+    chatMessageRepository.deleteAll().block(); // 저장소 초기화
+  }
 
-	@Test
-	public void testSaveChatMessage() {
-		ChatMessage chatMessage = ChatMessage.builder()
-			.content("Hello, AI!")
-			.responses(Arrays.asList("Hello, Human!"))
-			.timestamp(LocalDateTime.now())
-			.build();
+  /** 채팅 메시지를 저장하고, 올바르게 저장되었는지 확인하는 테스트입니다. */
+  @Test
+  public void testSaveChatMessage() {
+    // Given: 저장할 ChatMessage 객체 생성
+    ChatMessage chatMessage =
+        ChatMessage.builder()
+            .content("Hello, AI!")
+            .responses(Arrays.asList("Hello, Human!"))
+            .timestamp(LocalDateTime.now())
+            .build();
 
-		Mono<ChatMessage> savedMessage = chatMessageRepository.save(chatMessage);
+    // When: 저장소에 ChatMessage 저장
+    Mono<ChatMessage> savedMessage = chatMessageRepository.save(chatMessage);
 
-		StepVerifier.create(savedMessage)
-			.expectNextMatches(saved ->
-				saved.getId() != null &&
-					saved.getContent().equals("Hello, AI!") &&
-					saved.getResponses().get(0).equals("Hello, Human!")
-			)
-			.verifyComplete();
-	}
+    // Then: 저장된 메시지가 예상대로 저장되었는지 검증
+    StepVerifier.create(savedMessage)
+        .expectNextMatches(
+            saved ->
+                saved.getId() != null
+                    && saved.getContent().equals("Hello, AI!")
+                    && saved.getResponses().get(0).equals("Hello, Human!"))
+        .verifyComplete();
+  }
 
-	@Test
-	public void testFindAllChatMessages() {
-		ChatMessage message1 = ChatMessage.builder()
-			.content("Message 1")
-			.responses(Arrays.asList("Response 1"))
-			.timestamp(LocalDateTime.now())
-			.build();
+  /**
+   * 모든 채팅 메시지를 조회하는 테스트입니다.
+   */
+  @Test
+  public void testFindAllChatMessages() {
+    // Given: 두 개의 ChatMessage 객체 생성
+    ChatMessage message1 =
+        ChatMessage.builder()
+            .content("Message 1")
+            .responses(Arrays.asList("Response 1"))
+            .timestamp(LocalDateTime.now())
+            .build();
 
-		ChatMessage message2 = ChatMessage.builder()
-			.content("Message 2")
-			.responses(Arrays.asList("Response 2"))
-			.timestamp(LocalDateTime.now())
-			.build();
+    ChatMessage message2 =
+        ChatMessage.builder()
+            .content("Message 2")
+            .responses(Arrays.asList("Response 2"))
+            .timestamp(LocalDateTime.now())
+            .build();
 
-		chatMessageRepository.saveAll(Arrays.asList(message1, message2)).blockLast();
+    // When: 두 메시지를 저장소에 저장
+    chatMessageRepository.saveAll(Arrays.asList(message1, message2)).blockLast();
 
-		Flux<ChatMessage> allMessages = chatMessageRepository.findAll();
+    // Then: 저장된 모든 메시지를 조회하고 개수를 검증
+    Flux<ChatMessage> allMessages = chatMessageRepository.findAll();
+    StepVerifier.create(allMessages).expectNextCount(2).verifyComplete();
+  }
 
-		StepVerifier.create(allMessages)
-			.expectNextCount(2)
-			.verifyComplete();
-	}
+  /**
+   * ID로 채팅 메시지를 조회하는 테스트입니다.
+   */
+  @Test
+  public void testFindChatMessageById() {
+    // Given: 저장할 ChatMessage 객체 생성
+    ChatMessage chatMessage =
+        ChatMessage.builder()
+            .content("Find me!")
+            .responses(Arrays.asList("Found you!"))
+            .timestamp(LocalDateTime.now())
+            .build();
 
-	@Test
-	public void testFindChatMessageById() {
-		ChatMessage chatMessage = ChatMessage.builder()
-			.content("Find me!")
-			.responses(Arrays.asList("Found you!"))
-			.timestamp(LocalDateTime.now())
-			.build();
+    // When: 메시지를 저장하고, 해당 메시지의 ID를 통해 조회
+    String id = chatMessageRepository.save(chatMessage).block().getId();
+    Mono<ChatMessage> foundMessage = chatMessageRepository.findById(id);
 
-		String id = chatMessageRepository.save(chatMessage).block().getId();
+    // Then: 조회된 메시지가 올바른지 검증
+    StepVerifier.create(foundMessage)
+        .expectNextMatches(
+            found -> found.getId().equals(id) && found.getContent().equals("Find me!"))
+        .verifyComplete();
+  }
 
-		Mono<ChatMessage> foundMessage = chatMessageRepository.findById(id);
+  /**
+   * 채팅 메시지를 업데이트하는 테스트입니다.
+   */
+  @Test
+  public void testUpdateChatMessage() {
+    // Given: 저장할 ChatMessage 객체 생성
+    ChatMessage chatMessage =
+        ChatMessage.builder()
+            .content("Original content")
+            .responses(Arrays.asList("Original response"))
+            .timestamp(LocalDateTime.now())
+            .build();
 
-		StepVerifier.create(foundMessage)
-			.expectNextMatches(found ->
-				found.getId().equals(id) &&
-					found.getContent().equals("Find me!")
-			)
-			.verifyComplete();
-	}
+    // When: 메시지를 저장한 후 응답을 업데이트
+    String id = chatMessageRepository.save(chatMessage).block().getId();
 
-	@Test
-	public void testUpdateChatMessage() {
-		ChatMessage chatMessage = ChatMessage.builder()
-			.content("Original content")
-			.responses(Arrays.asList("Original response"))
-			.timestamp(LocalDateTime.now())
-			.build();
+    Mono<ChatMessage> updatedMessage =
+        chatMessageRepository
+            .findById(id)
+            .map(
+                message -> {
+                  message.appendResponse("Updated response");
+                  return message;
+                })
+            .flatMap(chatMessageRepository::save);
 
-		String id = chatMessageRepository.save(chatMessage).block().getId();
+    // Then: 업데이트된 메시지가 올바른지 검증
+    StepVerifier.create(updatedMessage)
+        .expectNextMatches(
+            updated ->
+                updated.getId().equals(id)
+                    && updated.getResponses().size() == 2
+                    && updated.getResponses().get(1).equals("Updated response"))
+        .verifyComplete();
+  }
 
-		Mono<ChatMessage> updatedMessage = chatMessageRepository.findById(id)
-			.map(message -> {
-				message.appendResponse("Updated response");
-				return message;
-			})
-			.flatMap(chatMessageRepository::save);
+  /**
+   * 채팅 메시지를 삭제하는 테스트입니다.
+   */
+  @Test
+  public void testDeleteChatMessage() {
+    // Given: 저장할 ChatMessage 객체 생성
+    ChatMessage chatMessage =
+        ChatMessage.builder()
+            .content("Delete me")
+            .responses(Arrays.asList("Goodbye!"))
+            .timestamp(LocalDateTime.now())
+            .build();
 
-		StepVerifier.create(updatedMessage)
-			.expectNextMatches(updated ->
-				updated.getId().equals(id) &&
-					updated.getResponses().size() == 2 &&
-					updated.getResponses().get(1).equals("Updated response")
-			)
-			.verifyComplete();
-	}
+    // When: 메시지를 저장한 후 해당 메시지를 삭제
+    String id = chatMessageRepository.save(chatMessage).block().getId();
+    Mono<Void> deleteResult = chatMessageRepository.deleteById(id);
 
-	@Test
-	public void testDeleteChatMessage() {
-		ChatMessage chatMessage = ChatMessage.builder()
-			.content("Delete me")
-			.responses(Arrays.asList("Goodbye!"))
-			.timestamp(LocalDateTime.now())
-			.build();
-
-		String id = chatMessageRepository.save(chatMessage).block().getId();
-
-		Mono<Void> deleteResult = chatMessageRepository.deleteById(id);
-
-		StepVerifier.create(deleteResult)
-			.verifyComplete();
-
-		Mono<ChatMessage> findResult = chatMessageRepository.findById(id);
-
-		StepVerifier.create(findResult)
-			.expectNextCount(0)
-			.verifyComplete();
-	}
+    // Then: 삭제된 메시지를 검증
+    StepVerifier.create(deleteResult).verifyComplete();
+    Mono<ChatMessage> findResult = chatMessageRepository.findById(id);
+    StepVerifier.create(findResult).expectNextCount(0).verifyComplete();
+  }
 }

--- a/src/test/java/com/example/algoyai/repository/chatbot/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/example/algoyai/repository/chatbot/ChatMessageRepositoryTest.java
@@ -1,0 +1,135 @@
+package com.example.algoyai.repository.chatbot;
+
+import com.example.algoyai.model.entity.chatbot.ChatMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+@DataMongoTest
+public class ChatMessageRepositoryTest {
+
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
+
+	@BeforeEach
+	public void setUp() {
+		chatMessageRepository.deleteAll().block();
+	}
+
+	@Test
+	public void testSaveChatMessage() {
+		ChatMessage chatMessage = ChatMessage.builder()
+			.content("Hello, AI!")
+			.responses(Arrays.asList("Hello, Human!"))
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		Mono<ChatMessage> savedMessage = chatMessageRepository.save(chatMessage);
+
+		StepVerifier.create(savedMessage)
+			.expectNextMatches(saved ->
+				saved.getId() != null &&
+					saved.getContent().equals("Hello, AI!") &&
+					saved.getResponses().get(0).equals("Hello, Human!")
+			)
+			.verifyComplete();
+	}
+
+	@Test
+	public void testFindAllChatMessages() {
+		ChatMessage message1 = ChatMessage.builder()
+			.content("Message 1")
+			.responses(Arrays.asList("Response 1"))
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		ChatMessage message2 = ChatMessage.builder()
+			.content("Message 2")
+			.responses(Arrays.asList("Response 2"))
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		chatMessageRepository.saveAll(Arrays.asList(message1, message2)).blockLast();
+
+		Flux<ChatMessage> allMessages = chatMessageRepository.findAll();
+
+		StepVerifier.create(allMessages)
+			.expectNextCount(2)
+			.verifyComplete();
+	}
+
+	@Test
+	public void testFindChatMessageById() {
+		ChatMessage chatMessage = ChatMessage.builder()
+			.content("Find me!")
+			.responses(Arrays.asList("Found you!"))
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		String id = chatMessageRepository.save(chatMessage).block().getId();
+
+		Mono<ChatMessage> foundMessage = chatMessageRepository.findById(id);
+
+		StepVerifier.create(foundMessage)
+			.expectNextMatches(found ->
+				found.getId().equals(id) &&
+					found.getContent().equals("Find me!")
+			)
+			.verifyComplete();
+	}
+
+	@Test
+	public void testUpdateChatMessage() {
+		ChatMessage chatMessage = ChatMessage.builder()
+			.content("Original content")
+			.responses(Arrays.asList("Original response"))
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		String id = chatMessageRepository.save(chatMessage).block().getId();
+
+		Mono<ChatMessage> updatedMessage = chatMessageRepository.findById(id)
+			.map(message -> {
+				message.appendResponse("Updated response");
+				return message;
+			})
+			.flatMap(chatMessageRepository::save);
+
+		StepVerifier.create(updatedMessage)
+			.expectNextMatches(updated ->
+				updated.getId().equals(id) &&
+					updated.getResponses().size() == 2 &&
+					updated.getResponses().get(1).equals("Updated response")
+			)
+			.verifyComplete();
+	}
+
+	@Test
+	public void testDeleteChatMessage() {
+		ChatMessage chatMessage = ChatMessage.builder()
+			.content("Delete me")
+			.responses(Arrays.asList("Goodbye!"))
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		String id = chatMessageRepository.save(chatMessage).block().getId();
+
+		Mono<Void> deleteResult = chatMessageRepository.deleteById(id);
+
+		StepVerifier.create(deleteResult)
+			.verifyComplete();
+
+		Mono<ChatMessage> findResult = chatMessageRepository.findById(id);
+
+		StepVerifier.create(findResult)
+			.expectNextCount(0)
+			.verifyComplete();
+	}
+}

--- a/src/test/java/com/example/algoyai/service/chatbot/ChatServiceTest.java
+++ b/src/test/java/com/example/algoyai/service/chatbot/ChatServiceTest.java
@@ -1,0 +1,165 @@
+package com.example.algoyai.service.chatbot;
+
+import com.example.algoyai.model.dto.chatbot.ChatMessageDto;
+import com.example.algoyai.model.entity.chatbot.ChatMessage;
+import com.example.algoyai.repository.chatbot.ChatMessageRepository;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ChatServiceTest {
+
+	private ChatService chatService;
+
+	@Mock
+	private WebClient.Builder webClientBuilder;
+
+	@Mock
+	private WebClient webClient;
+
+	@Mock
+	private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+	@Mock
+	private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+	@Mock
+	private WebClient.ResponseSpec responseSpec;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+		when(webClientBuilder.build()).thenReturn(webClient);
+		chatService = new ChatService(webClientBuilder, "http://test-api-url.com", chatMessageRepository);
+	}
+
+	@Test
+	void testGetChatResponse() {
+		ChatMessage chatMessage = ChatMessage.builder()
+			.id("1")
+			.content("Hello")
+			.responses(Arrays.asList())
+			.timestamp(LocalDateTime.now())
+			.build();
+
+		ChatMessageDto chatMessageDto = ChatMessageDto.builder()
+			.type("response")
+			.data(ChatMessageDto.ChatResponseData.builder()
+				.content("AI generated response")
+				.build())
+			.build();
+
+		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(chatMessage));
+		when(webClient.get()).thenReturn(requestHeadersUriSpec);
+		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.just(chatMessageDto));
+
+		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+
+		StepVerifier.create(result)
+			.expectNextMatches(dto ->
+				(dto.getType().equals("response") && dto.getData() != null && dto.getData().getContent() != null) ||
+					(dto.getType().equals("error") && dto.getData() != null && dto.getData().getContent() != null)
+			)
+			.verifyComplete();
+
+		verify(chatMessageRepository, atLeast(1)).save(any(ChatMessage.class));
+	}
+
+	@Test
+	void testGetChatResponseWithError() {
+		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
+		when(webClient.get()).thenReturn(requestHeadersUriSpec);
+		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.error(new RuntimeException("API Error")));
+
+		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+
+		StepVerifier.create(result)
+			.expectNextMatches(dto -> dto.getType().equals("error") &&
+				dto.getData().getContent().startsWith("Error:"))
+			.verifyComplete();
+	}
+
+	@Test
+	void testGetChatResponseTimeout() {
+		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
+		when(webClient.get()).thenReturn(requestHeadersUriSpec);
+		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+
+		// 타임아웃 시뮬레이션
+		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.error(new TimeoutException("Simulated timeout")));
+
+		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+
+		StepVerifier.create(result)
+			.expectNextMatches(dto -> dto.getType().equals("error") &&
+				dto.getData().getContent().contains("timed out"))
+			.expectComplete()
+			.verify(Duration.ofSeconds(5));
+	}
+
+	@Test
+	void testGetChatResponseMultipleMessages() {
+		ChatMessageDto message1 = ChatMessageDto.builder()
+			.type("response")
+			.data(ChatMessageDto.ChatResponseData.builder()
+				.content("Hello")
+				.build())
+			.build();
+		ChatMessageDto message2 = ChatMessageDto.builder()
+			.type("response")
+			.data(ChatMessageDto.ChatResponseData.builder()
+				.content("How can I help you?")
+				.build())
+			.build();
+
+		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
+		when(webClient.get()).thenReturn(requestHeadersUriSpec);
+		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.just(message1, message2));
+
+		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+
+		StepVerifier.create(result)
+			.expectNextMatches(dto -> dto.getData().getContent().equals("Hello"))
+			.expectNextMatches(dto -> dto.getData().getContent().equals("How can I help you?"))
+			.verifyComplete();
+	}
+
+	@Test
+	void testGetChatResponseEmptyResponse() {
+		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
+		when(webClient.get()).thenReturn(requestHeadersUriSpec);
+		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.empty());
+
+		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+
+		StepVerifier.create(result)
+			.expectNextCount(0)
+			.verifyComplete();
+	}
+}

--- a/src/test/java/com/example/algoyai/service/chatbot/ChatServiceTest.java
+++ b/src/test/java/com/example/algoyai/service/chatbot/ChatServiceTest.java
@@ -20,146 +20,181 @@ import java.util.Arrays;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+/**
+ * @author JSW
+ * ChatService의 동작을 검증하는 테스트 클래스입니다.
+ */
 class ChatServiceTest {
 
-	private ChatService chatService;
+  private ChatService chatService;
 
-	@Mock
-	private WebClient.Builder webClientBuilder;
+  @Mock private WebClient.Builder webClientBuilder;
+  @Mock private WebClient webClient;
+  @Mock private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+  @Mock private WebClient.RequestHeadersSpec requestHeadersSpec;
+  @Mock private WebClient.ResponseSpec responseSpec;
+  @Mock private ChatMessageRepository chatMessageRepository;
 
-	@Mock
-	private WebClient webClient;
+  /**
+   * 테스트 전 Mock 객체 초기화 및 WebClient 설정
+   */
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+    when(webClientBuilder.build()).thenReturn(webClient);
+    chatService =
+        new ChatService(webClientBuilder, "http://test-api-url.com", chatMessageRepository);
+  }
 
-	@Mock
-	private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+  /**
+   * 정상적으로 채팅 응답을 가져오는 경우를 테스트합니다.
+   */
+  @Test
+  void testGetChatResponse() {
+    // Given: ChatMessage와 ChatMessageDto 생성
+    ChatMessage chatMessage =
+        ChatMessage.builder()
+            .id("1")
+            .content("Hello")
+            .responses(Arrays.asList())
+            .timestamp(LocalDateTime.now())
+            .build();
 
-	@Mock
-	private WebClient.RequestHeadersSpec requestHeadersSpec;
+    ChatMessageDto chatMessageDto =
+        ChatMessageDto.builder()
+            .type("response")
+            .data(
+                ChatMessageDto.ChatResponseData.builder().content("AI generated response").build())
+            .build();
 
-	@Mock
-	private WebClient.ResponseSpec responseSpec;
+    // When: chatMessageRepository 및 WebClient의 동작 설정
+    when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(chatMessage));
+    when(webClient.get()).thenReturn(requestHeadersUriSpec);
+    when(requestHeadersUriSpec.uri(any(java.util.function.Function.class)))
+        .thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.just(chatMessageDto));
 
-	@Mock
-	private ChatMessageRepository chatMessageRepository;
+    // Then: 채팅 응답 Flux를 생성하고 결과를 검증
+    Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
 
-	@BeforeEach
-	void setUp() {
-		MockitoAnnotations.openMocks(this);
-		when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
-		when(webClientBuilder.build()).thenReturn(webClient);
-		chatService = new ChatService(webClientBuilder, "http://test-api-url.com", chatMessageRepository);
-	}
+    StepVerifier.create(result)
+        .expectNextMatches(
+            dto ->
+                (dto.getType().equals("response")
+                        && dto.getData() != null
+                        && dto.getData().getContent() != null)
+                    || (dto.getType().equals("error")
+                        && dto.getData() != null
+                        && dto.getData().getContent() != null))
+        .verifyComplete();
 
-	@Test
-	void testGetChatResponse() {
-		ChatMessage chatMessage = ChatMessage.builder()
-			.id("1")
-			.content("Hello")
-			.responses(Arrays.asList())
-			.timestamp(LocalDateTime.now())
-			.build();
+    verify(chatMessageRepository, atLeast(1)).save(any(ChatMessage.class));
+  }
 
-		ChatMessageDto chatMessageDto = ChatMessageDto.builder()
-			.type("response")
-			.data(ChatMessageDto.ChatResponseData.builder()
-				.content("AI generated response")
-				.build())
-			.build();
+  /**
+   * 채팅 응답에서 에러가 발생하는 경우를 테스트합니다.
+   */
+  @Test
+  void testGetChatResponseWithError() {
+    // Given: 저장된 채팅 메시지 및 WebClient 에러 설정
+    when(chatMessageRepository.save(any(ChatMessage.class)))
+        .thenReturn(Mono.just(ChatMessage.builder().build()));
+    when(webClient.get()).thenReturn(requestHeadersUriSpec);
+    when(requestHeadersUriSpec.uri(any(java.util.function.Function.class)))
+        .thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToFlux(ChatMessageDto.class))
+        .thenReturn(Flux.error(new RuntimeException("API Error")));
 
-		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(chatMessage));
-		when(webClient.get()).thenReturn(requestHeadersUriSpec);
-		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
-		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.just(chatMessageDto));
+    // Then: 에러 메시지가 포함된 결과를 검증
+    Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
 
-		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+    StepVerifier.create(result)
+        .expectNextMatches(
+            dto -> dto.getType().equals("error") && dto.getData().getContent().startsWith("Error:"))
+        .verifyComplete();
+  }
 
-		StepVerifier.create(result)
-			.expectNextMatches(dto ->
-				(dto.getType().equals("response") && dto.getData() != null && dto.getData().getContent() != null) ||
-					(dto.getType().equals("error") && dto.getData() != null && dto.getData().getContent() != null)
-			)
-			.verifyComplete();
+  /**
+   * 채팅 응답이 타임아웃되는 경우를 테스트합니다.
+   */
+  @Test
+  void testGetChatResponseTimeout() {
+    // Given: 타임아웃 에러를 시뮬레이션
+    when(chatMessageRepository.save(any(ChatMessage.class)))
+        .thenReturn(Mono.just(ChatMessage.builder().build()));
+    when(webClient.get()).thenReturn(requestHeadersUriSpec);
+    when(requestHeadersUriSpec.uri(any(java.util.function.Function.class)))
+        .thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToFlux(ChatMessageDto.class))
+        .thenReturn(Flux.error(new TimeoutException("Simulated timeout")));
 
-		verify(chatMessageRepository, atLeast(1)).save(any(ChatMessage.class));
-	}
+    // Then: 타임아웃 메시지가 포함된 결과를 검증
+    Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
 
-	@Test
-	void testGetChatResponseWithError() {
-		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
-		when(webClient.get()).thenReturn(requestHeadersUriSpec);
-		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
-		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.error(new RuntimeException("API Error")));
+    StepVerifier.create(result)
+        .expectNextMatches(
+            dto ->
+                dto.getType().equals("error") && dto.getData().getContent().contains("timed out"))
+        .expectComplete()
+        .verify(Duration.ofSeconds(5));
+  }
 
-		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+  /**
+   * 여러 개의 채팅 응답을 순차적으로 받는 경우를 테스트합니다.
+   */
+  @Test
+  void testGetChatResponseMultipleMessages() {
+    // Given: 여러 개의 응답 메시지 생성
+    ChatMessageDto message1 =
+        ChatMessageDto.builder()
+            .type("response")
+            .data(ChatMessageDto.ChatResponseData.builder().content("Hello").build())
+            .build();
+    ChatMessageDto message2 =
+        ChatMessageDto.builder()
+            .type("response")
+            .data(ChatMessageDto.ChatResponseData.builder().content("How can I help you?").build())
+            .build();
 
-		StepVerifier.create(result)
-			.expectNextMatches(dto -> dto.getType().equals("error") &&
-				dto.getData().getContent().startsWith("Error:"))
-			.verifyComplete();
-	}
+    // When: WebClient가 여러 개의 응답을 반환하도록 설정
+    when(chatMessageRepository.save(any(ChatMessage.class)))
+        .thenReturn(Mono.just(ChatMessage.builder().build()));
+    when(webClient.get()).thenReturn(requestHeadersUriSpec);
+    when(requestHeadersUriSpec.uri(any(java.util.function.Function.class)))
+        .thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.just(message1, message2));
 
-	@Test
-	void testGetChatResponseTimeout() {
-		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
-		when(webClient.get()).thenReturn(requestHeadersUriSpec);
-		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
-		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    // Then: 두 개의 메시지를 순차적으로 받는지 검증
+    Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
 
-		// 타임아웃 시뮬레이션
-		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.error(new TimeoutException("Simulated timeout")));
+    StepVerifier.create(result)
+        .expectNextMatches(dto -> dto.getData().getContent().equals("Hello"))
+        .expectNextMatches(dto -> dto.getData().getContent().equals("How can I help you?"))
+        .verifyComplete();
+  }
 
-		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
+  /**
+   * 빈 응답을 받는 경우를 테스트합니다.
+   */
+  @Test
+  void testGetChatResponseEmptyResponse() {
+    // Given: WebClient가 빈 Flux를 반환하도록 설정
+    when(chatMessageRepository.save(any(ChatMessage.class)))
+        .thenReturn(Mono.just(ChatMessage.builder().build()));
+    when(webClient.get()).thenReturn(requestHeadersUriSpec);
+    when(requestHeadersUriSpec.uri(any(java.util.function.Function.class)))
+        .thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.empty());
 
-		StepVerifier.create(result)
-			.expectNextMatches(dto -> dto.getType().equals("error") &&
-				dto.getData().getContent().contains("timed out"))
-			.expectComplete()
-			.verify(Duration.ofSeconds(5));
-	}
+    // Then: 빈 응답을 받는지 검증
+    Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
 
-	@Test
-	void testGetChatResponseMultipleMessages() {
-		ChatMessageDto message1 = ChatMessageDto.builder()
-			.type("response")
-			.data(ChatMessageDto.ChatResponseData.builder()
-				.content("Hello")
-				.build())
-			.build();
-		ChatMessageDto message2 = ChatMessageDto.builder()
-			.type("response")
-			.data(ChatMessageDto.ChatResponseData.builder()
-				.content("How can I help you?")
-				.build())
-			.build();
-
-		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
-		when(webClient.get()).thenReturn(requestHeadersUriSpec);
-		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
-		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.just(message1, message2));
-
-		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
-
-		StepVerifier.create(result)
-			.expectNextMatches(dto -> dto.getData().getContent().equals("Hello"))
-			.expectNextMatches(dto -> dto.getData().getContent().equals("How can I help you?"))
-			.verifyComplete();
-	}
-
-	@Test
-	void testGetChatResponseEmptyResponse() {
-		when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(Mono.just(ChatMessage.builder().build()));
-		when(webClient.get()).thenReturn(requestHeadersUriSpec);
-		when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
-		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-		when(responseSpec.bodyToFlux(ChatMessageDto.class)).thenReturn(Flux.empty());
-
-		Flux<ChatMessageDto> result = chatService.getChatResponse("Hello");
-
-		StepVerifier.create(result)
-			.expectNextCount(0)
-			.verifyComplete();
-	}
+    StepVerifier.create(result).expectNextCount(0).verifyComplete();
+  }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  mongodb:
+    embedded:
+      version: 4.0.21


### PR DESCRIPTION
## 요약
- 챗봇 테스트 코드 작성

## 관련 이슈
- Closed #107 

## 변경 사항
- build.gradle에 "org.testcontainers:junit-jupiter:1.17.3", "org.testcontainers:mongodb:1.17.3", 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.6.1' 추가
- test/resources/application.yml 추가
- test/controller: 챗봇 컨트롤러 테스트 코드 5개 작성
- test/service: 챗봇 서비스 테스트 코드 5개 작성
- test/repository: 챗봇 레포지토리 테스트 코드 5개 작성

## 기타
- ChatService 응답을 받는 메서드의 오류 처리 로직을 리팩토링 하였습니다.