### PR TITLE
Bug:테스트 코드 추가 후 ci/cd 실패

### DIFF
--- a/src/main/java/com/example/algoyai/model/entity/chatbot/ChatMessage.java
+++ b/src/main/java/com/example/algoyai/model/entity/chatbot/ChatMessage.java
@@ -36,9 +36,11 @@ public class ChatMessage {
 	 * @param response 추가할 응답 내용
 	 * @return 이 ChatMessage 객체 자신을 반환하여 메서드 체이닝을 지원합니다.
 	 */
-	public ChatMessage appendResponse(String response) {
+	public void appendResponse(String response) {
+		if (this.responses == null) {
+			this.responses = new ArrayList<>();
+		}
 		this.responses.add(response);
-		return this;
 	}
 
 	/**

--- a/src/test/java/com/example/algoyai/repository/chatbot/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/example/algoyai/repository/chatbot/ChatMessageRepositoryTest.java
@@ -1,13 +1,12 @@
 package com.example.algoyai.repository.chatbot;
 
 import com.example.algoyai.model.entity.chatbot.ChatMessage;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
@@ -21,35 +20,37 @@ import java.util.Arrays;
 @AutoConfigureDataMongo
 public class ChatMessageRepositoryTest {
 
-  @Autowired private ChatMessageRepository chatMessageRepository;
+  @Autowired
+  private ChatMessageRepository chatMessageRepository;
 
-  /** 각 테스트 실행 전에 저장소를 비웁니다. */
+  /**
+   * 각 테스트 실행 전에 저장소의 모든 데이터를 삭제합니다.
+   */
   @BeforeEach
   public void setUp() {
-    chatMessageRepository.deleteAll().block(); // 저장소 초기화
+    StepVerifier.create(chatMessageRepository.deleteAll())
+        .verifyComplete(); // 저장소를 비운 후 테스트 진행
   }
 
-  /** 채팅 메시지를 저장하고, 올바르게 저장되었는지 확인하는 테스트입니다. */
+  /**
+   * 채팅 메시지를 저장하고, 저장된 메시지가 예상대로 저장되었는지 확인하는 테스트입니다.
+   */
   @Test
   public void testSaveChatMessage() {
     // Given: 저장할 ChatMessage 객체 생성
-    ChatMessage chatMessage =
-        ChatMessage.builder()
-            .content("Hello, AI!")
-            .responses(Arrays.asList("Hello, Human!"))
-            .timestamp(LocalDateTime.now())
-            .build();
+    ChatMessage chatMessage = ChatMessage.builder()
+        .content("Hello, AI!")
+        .responses(Arrays.asList("Hello, Human!"))
+        .timestamp(LocalDateTime.now())
+        .build();
 
-    // When: 저장소에 ChatMessage 저장
-    Mono<ChatMessage> savedMessage = chatMessageRepository.save(chatMessage);
-
-    // Then: 저장된 메시지가 예상대로 저장되었는지 검증
-    StepVerifier.create(savedMessage)
-        .expectNextMatches(
-            saved ->
-                saved.getId() != null
-                    && saved.getContent().equals("Hello, AI!")
-                    && saved.getResponses().get(0).equals("Hello, Human!"))
+    // When & Then: 메시지를 저장하고, 저장된 데이터가 올바른지 검증
+    StepVerifier.create(chatMessageRepository.save(chatMessage))
+        .expectNextMatches(saved ->
+            saved.getId() != null &&
+                saved.getContent().equals("Hello, AI!") &&
+                saved.getResponses().get(0).equals("Hello, Human!")
+        )
         .verifyComplete();
   }
 
@@ -59,49 +60,45 @@ public class ChatMessageRepositoryTest {
   @Test
   public void testFindAllChatMessages() {
     // Given: 두 개의 ChatMessage 객체 생성
-    ChatMessage message1 =
-        ChatMessage.builder()
-            .content("Message 1")
-            .responses(Arrays.asList("Response 1"))
-            .timestamp(LocalDateTime.now())
-            .build();
+    ChatMessage message1 = ChatMessage.builder()
+        .content("Message 1")
+        .responses(Arrays.asList("Response 1"))
+        .timestamp(LocalDateTime.now())
+        .build();
 
-    ChatMessage message2 =
-        ChatMessage.builder()
-            .content("Message 2")
-            .responses(Arrays.asList("Response 2"))
-            .timestamp(LocalDateTime.now())
-            .build();
+    ChatMessage message2 = ChatMessage.builder()
+        .content("Message 2")
+        .responses(Arrays.asList("Response 2"))
+        .timestamp(LocalDateTime.now())
+        .build();
 
-    // When: 두 메시지를 저장소에 저장
-    chatMessageRepository.saveAll(Arrays.asList(message1, message2)).blockLast();
-
-    // Then: 저장된 모든 메시지를 조회하고 개수를 검증
-    Flux<ChatMessage> allMessages = chatMessageRepository.findAll();
-    StepVerifier.create(allMessages).expectNextCount(2).verifyComplete();
+    // When: 두 메시지를 저장소에 저장한 후, 모든 메시지를 조회
+    StepVerifier.create(chatMessageRepository.saveAll(Arrays.asList(message1, message2))
+            .thenMany(chatMessageRepository.findAll())) // 저장 후 조회
+        .expectNextCount(2) // 두 개의 메시지를 기대
+        .verifyComplete();
   }
 
   /**
-   * ID로 채팅 메시지를 조회하는 테스트입니다.
+   * ID로 특정 채팅 메시지를 조회하는 테스트입니다.
    */
   @Test
   public void testFindChatMessageById() {
     // Given: 저장할 ChatMessage 객체 생성
-    ChatMessage chatMessage =
-        ChatMessage.builder()
-            .content("Find me!")
-            .responses(Arrays.asList("Found you!"))
-            .timestamp(LocalDateTime.now())
-            .build();
+    ChatMessage chatMessage = ChatMessage.builder()
+        .content("Find me!")
+        .responses(Arrays.asList("Found you!"))
+        .timestamp(LocalDateTime.now())
+        .build();
 
-    // When: 메시지를 저장하고, 해당 메시지의 ID를 통해 조회
-    String id = chatMessageRepository.save(chatMessage).block().getId();
-    Mono<ChatMessage> foundMessage = chatMessageRepository.findById(id);
-
-    // Then: 조회된 메시지가 올바른지 검증
-    StepVerifier.create(foundMessage)
-        .expectNextMatches(
-            found -> found.getId().equals(id) && found.getContent().equals("Find me!"))
+    // When: 메시지를 저장한 후, 저장된 메시지의 ID를 사용하여 조회
+    StepVerifier.create(chatMessageRepository.save(chatMessage)
+            .flatMap(saved -> chatMessageRepository.findById(saved.getId())))
+        // Then: 조회된 메시지가 예상과 일치하는지 검증
+        .expectNextMatches(found ->
+            found.getContent().equals("Find me!") &&
+                found.getResponses().get(0).equals("Found you!")
+        )
         .verifyComplete();
   }
 
@@ -111,33 +108,23 @@ public class ChatMessageRepositoryTest {
   @Test
   public void testUpdateChatMessage() {
     // Given: 저장할 ChatMessage 객체 생성
-    ChatMessage chatMessage =
-        ChatMessage.builder()
-            .content("Original content")
-            .responses(Arrays.asList("Original response"))
-            .timestamp(LocalDateTime.now())
-            .build();
+    ChatMessage chatMessage = ChatMessage.builder()
+        .content("Original content")
+        .responses(new ArrayList<>(Arrays.asList("Original response")))
+        .timestamp(LocalDateTime.now())
+        .build();
 
-    // When: 메시지를 저장한 후 응답을 업데이트
-    String id = chatMessageRepository.save(chatMessage).block().getId();
-
-    Mono<ChatMessage> updatedMessage =
-        chatMessageRepository
-            .findById(id)
-            .map(
-                message -> {
-                  message.appendResponse("Updated response");
-                  return message;
-                })
-            .flatMap(chatMessageRepository::save);
-
-    // Then: 업데이트된 메시지가 올바른지 검증
-    StepVerifier.create(updatedMessage)
-        .expectNextMatches(
-            updated ->
-                updated.getId().equals(id)
-                    && updated.getResponses().size() == 2
-                    && updated.getResponses().get(1).equals("Updated response"))
+    // When: 메시지를 저장한 후, 응답을 업데이트하여 다시 저장
+    StepVerifier.create(chatMessageRepository.save(chatMessage)
+            .flatMap(saved -> {
+              saved.appendResponse("Updated response"); // 응답 추가
+              return chatMessageRepository.save(saved);
+            }))
+        // Then: 업데이트된 메시지가 올바르게 저장되었는지 검증
+        .expectNextMatches(updated ->
+            updated.getResponses().size() == 2 && // 응답이 두 개여야 함
+                updated.getResponses().get(1).equals("Updated response")
+        )
         .verifyComplete();
   }
 
@@ -147,20 +134,18 @@ public class ChatMessageRepositoryTest {
   @Test
   public void testDeleteChatMessage() {
     // Given: 저장할 ChatMessage 객체 생성
-    ChatMessage chatMessage =
-        ChatMessage.builder()
-            .content("Delete me")
-            .responses(Arrays.asList("Goodbye!"))
-            .timestamp(LocalDateTime.now())
-            .build();
+    ChatMessage chatMessage = ChatMessage.builder()
+        .content("Delete me")
+        .responses(Arrays.asList("Goodbye!"))
+        .timestamp(LocalDateTime.now())
+        .build();
 
     // When: 메시지를 저장한 후 해당 메시지를 삭제
-    String id = chatMessageRepository.save(chatMessage).block().getId();
-    Mono<Void> deleteResult = chatMessageRepository.deleteById(id);
-
-    // Then: 삭제된 메시지를 검증
-    StepVerifier.create(deleteResult).verifyComplete();
-    Mono<ChatMessage> findResult = chatMessageRepository.findById(id);
-    StepVerifier.create(findResult).expectNextCount(0).verifyComplete();
+    StepVerifier.create(chatMessageRepository.save(chatMessage)
+            .flatMap(saved -> chatMessageRepository.deleteById(saved.getId())
+                .then(chatMessageRepository.findById(saved.getId())))) // 삭제 후 조회
+        // Then: 삭제된 메시지가 더 이상 존재하지 않음을 검증
+        .expectNextCount(0) // 삭제 후 메시지가 없음을 기대
+        .verifyComplete();
   }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,6 +5,3 @@ spring:
   data:
     mongodb:
       database: testdb
-logging:
-  level:
-    org.springframework.data.mongodb.core: DEBUG


### PR DESCRIPTION
## 요약
- 테스트 코드와 업데이트 메서드 void 반환형으로, 내부에 if문으로 변경

## 관련 이슈
- Related To #114 

## 변경 사항
- 모든 비동기 작업에 StepVerifier를 사용하여 일관된 비동기 테스트 방식을 적용했습니다.
- block() 메서드 호출을 제거하고 모든 작업을 리액티브 스트림으로 처리했습니다.
- 각 테스트 메서드에서 데이터 저장, 조회, 수정, 삭제 등의 작업을 연속된 리액티브 연산으로 구성했습니다.
- ChatMessage 클래스에서 responses 필드가 null일 경우를 처리합니다.
- appendResponse 메서드가 void 타입이 되어 더 명확한 의도를 전달합니다.
- ChatMessageMapper의 updateEntity 메서드가 ChatMessage 객체의 appendResponse 메서드를 직접 호출하여 일관성을 유지합니다.
- 테스트 코드에서 responses 리스트를 명시적으로 초기화하여 UnsupportedOperationException을 방지합니다.